### PR TITLE
Fix Docker Compose Command Usage and Cleanup Script - Issue #8

### DIFF
--- a/setup/docker/docker-setup-ubuntu.sh
+++ b/setup/docker/docker-setup-ubuntu.sh
@@ -159,9 +159,9 @@ sudo  sed -i "/mantis/d" /etc/hosts
 sudo -- sh -c -e "echo '10.10.0.3  mantis.db' >> /etc/hosts";
 sudo -- sh -c -e "echo '127.0.0.1  mantis.dashboard' >> /etc/hosts";
 
-appsmith_exists=$(docker-compose ps appsmith --quiet)
-mongo_exists=$(docker-compose ps mongodb --quiet)
-mantis_exists=$(docker-compose ps mantis --quiet)
+appsmith_exists=$(docker-compose ps appsmith)
+mongo_exists=$(docker-compose ps mongodb)
+mantis_exists=$(docker-compose ps mantis)
 
 if [ -n "$appsmith_exists" ] && [ -n "$mongo_exists" ] && [ -n "$mantis_exists" ]; then
 echo -e -n "

--- a/setup/docker/docker-setup-ubuntu.sh
+++ b/setup/docker/docker-setup-ubuntu.sh
@@ -51,8 +51,8 @@ Please ensure your system meets them before proceeding.
 1. Install Docker >= v19.0.0
    - https://docs.docker.com/engine/install/ubuntu/
    - Check version with 'docker --version'
-2. Install Docker compose >= v2.0.0
-   - Check version with 'docker compose version'
+2. Install docker-compose >= v2.0.0
+   - Check version with 'docker-compose version'
 4. sudo access on the machine
 5. Ports 1337, 1338, 27000 available on host machine (for Mantis dashboard and MongoDB)
     - If these ports can't be freed then modify the port mapping in docker-compose-mantis.yml 
@@ -73,10 +73,10 @@ fi
 
 sudo apt update && sudo apt install jq -y
 
-if docker compose ps | grep -q "Up"; then
+if docker-compose ps | grep -q "Up"; then
     echo -e "[?] ${BIYellow}Looks like this script was run previously to setup Mantis.${NC}\n"
 
-sudo docker compose ps --format json | jq -r '(. | [.Service, .State]) | @tsv' | column -ts $'\t'
+sudo docker-compose ps --format json | jq -r '(. | [.Service, .State]) | @tsv' | column -ts $'\t'
 
 echo -e -n "
 [!] ${Yellow}Previously created resources need to be cleaned up before proceeding with installation \n
@@ -103,22 +103,22 @@ read -p "What would you like to do? (1/2/3/4): " choice
 case $choice in
     1)
         echo -e "[-] ${Red}Removing all the existing containers from Mantis setup${NC}"
-        sudo docker compose down
+        sudo docker-compose down
         ;;
     2)
         echo -e "[-] ${Red}Removing Mantis, Appsmith and retaining MongoDB${NC}"
-        sudo docker compose down appsmith
-        sudo docker compose down mantis
+        sudo docker-compose down appsmith
+        sudo docker-compose down mantis
         ;;
     3)
         echo -e "[-] ${Red}Removing Mantis, MongoDB and retaining Appsmith${NC}"
-        sudo docker compose down mongodb
-        sudo docker compose down mantis
+        sudo docker-compose down mongodb
+        sudo docker-compose down mantis
         ;;
 
     4)
         echo -e "[-] ${Red}Removing Mantis and retaining MongoDB, Appsmith${NC}"
-        sudo docker compose down mantis
+        sudo docker-compose down mantis
         ;;
     *)
         echo -e "\nInvalid choice. Please select a valid option (1/2/3/4)."
@@ -149,19 +149,19 @@ echo -e -n "[?] ${BICyan}Do you have sudo access on the machine? (y/n)? ${NC}"
 # Install packages
 
 
-sudo docker compose up --remove-orphans -d --build
+sudo docker-compose up --remove-orphans -d --build
 
 echo -e "${BIYellow}\n\nSETUP SUMMARY${NC}\n"
 
-sudo docker compose ps --format json | jq -r '(. | [.Service, .State]) | @tsv' | column -ts $'\t'
+sudo docker-compose ps --format json | jq -r '(. | [.Service, .State]) | @tsv' | column -ts $'\t'
 
 sudo  sed -i "/mantis/d" /etc/hosts
 sudo -- sh -c -e "echo '10.10.0.3  mantis.db' >> /etc/hosts";
 sudo -- sh -c -e "echo '127.0.0.1  mantis.dashboard' >> /etc/hosts";
 
-appsmith_exists=$(docker compose ps appsmith --quiet)
-mongo_exists=$(docker compose ps mongodb --quiet)
-mantis_exists=$(docker compose ps mantis --quiet)
+appsmith_exists=$(docker-compose ps appsmith --quiet)
+mongo_exists=$(docker-compose ps mongodb --quiet)
+mantis_exists=$(docker-compose ps mantis --quiet)
 
 if [ -n "$appsmith_exists" ] && [ -n "$mongo_exists" ] && [ -n "$mantis_exists" ]; then
 echo -e -n "

--- a/setup/docker/docker-setup-ubuntu.sh
+++ b/setup/docker/docker-setup-ubuntu.sh
@@ -159,9 +159,9 @@ sudo  sed -i "/mantis/d" /etc/hosts
 sudo -- sh -c -e "echo '10.10.0.3  mantis.db' >> /etc/hosts";
 sudo -- sh -c -e "echo '127.0.0.1  mantis.dashboard' >> /etc/hosts";
 
-appsmith_exists=$(docker-compose ps appsmith)
-mongo_exists=$(docker-compose ps mongodb)
-mantis_exists=$(docker-compose ps mantis)
+appsmith_exists=$(docker-compose ps -q appsmith)
+mongo_exists=$(docker-compose ps -q mongodb)
+mantis_exists=$(docker-compose ps -q mantis)
 
 if [ -n "$appsmith_exists" ] && [ -n "$mongo_exists" ] && [ -n "$mantis_exists" ]; then
 echo -e -n "


### PR DESCRIPTION
# Fix Docker Compose Command and Cleanup Script

## Description
This PR addresses an issue where the Docker Compose command was failing due to incorrect usage of the `--quiet` flag. Additionally, some cleanup and formatting improvements were made to enhance readability and maintainability.

### Changes Made:
- Changed `docker compose` to `docker-compose` to properly execute Docker Compose commands.
- Removed unnecessary usage of the `--quiet` flag in the Docker Compose command.
- Minor cleanup and formatting improvements for clarity and readability.

## Checklist:
- [x] Verified that the script now executes without errors.

## Additional Notes:
- Please review the changes and verify that the script operates as expected.
- Suggestions and feedback are welcome for further improvements.

### Before the fix:

![image](https://github.com/PhonePe/mantis/assets/71321892/901c7530-9a96-4c69-a22f-0fbdb5618aad)
![image](https://github.com/PhonePe/mantis/assets/71321892/f412a988-1f61-4c2d-b475-62567a3420e2)


### After the fix:
![image](https://github.com/PhonePe/mantis/assets/71321892/3d602c35-139a-41c5-8b66-cd7eb9e46e23)


