### PR TITLE
limit unauthenticated mongodb exposure to localhost

### DIFF
--- a/setup/docker/docker-compose.yml
+++ b/setup/docker/docker-compose.yml
@@ -18,11 +18,11 @@ services:
     image: mongo:latest
     restart: always
     ports:
-      - "27000:27017"
+      - "127.0.0.1:27000:27017"
     networks:
       network:
         ipv4_address: 10.10.0.3
-    command: mongod --bind_ip 0.0.0.0
+    command: mongod --bind_ip 10.10.0.3
     environment:
       MONGO_INITDB_ROOT_DATABASE: mantis
     volumes:


### PR DESCRIPTION

Without this change, a default installation of mantis on a Ubuntu 22.04 node exposes the mongodb container to any public-facing interfaces available on the underlying VM.