### PR TITLE
Fixed RUN command of Dockerfile for dashboard and fixed busy waiting in docker-compose file under setup/docker

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 python:3.12-slim
 
-RUN apt-get update -y && apt-get upgrade
+RUN apt-get update -y && apt-get upgrade -y
 
 # Setup work directory
 WORKDIR /home/

--- a/setup/docker/docker-compose.yml
+++ b/setup/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../../
     container_name: mantis
     restart: on-failure
-    command:  tail -F /dev/random
+    command: sleep infinity
     networks:
       network:
         ipv4_address: 10.10.0.2


### PR DESCRIPTION
While going through the 100% CPU Utilization Issue (Busy Waiting Issue) I found that the docker-compose file using "tail -F /dev/random" to keep container alive. This causes CPU as well as File System Utilization. So the better way to do this using sleep command. It don't keep the CPU busy. So it solves Busy Waiting Issue.

While debugging this issue i found another Issue with Dockerfile of dashboard due to which build process was failing. 