### PR TITLE
fixed mongo issue for M1/M2 Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,20 @@ cd mantis/setup/docker
 
 Run the respective docker setup file based on your OS
 
+*Note: If you are using MacOS with ARM architecture (M1/M2/M3) create a `.env` in the `setup/docker` folder with the following env variable.*
+
+```
+MAC_PLATFORM=linux/arm64
+```
+
 ```
 ./docker-setup-macos.sh
 
 ./docker-setup-ubuntu.sh
 ```
+
+
+
 
 For uninstalling Mantis (remove all the resources created by installation), run the following command in the same directory
 

--- a/setup/docker/.gitignore
+++ b/setup/docker/.gitignore
@@ -1,2 +1,3 @@
 *stacks*
 *configs*
+.env

--- a/setup/docker/docker-compose.yml
+++ b/setup/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - "PS1='Mantis > '"
   mongodb:
+    platform: "${MAC_PLATFORM:-linux/amd64}"
     container_name: mongodb
     image: mongo:latest
     restart: always


### PR DESCRIPTION
Mongodb docker has some issues running on Mac M1/M2 machines due to architecture differences. So providing the platform arg in mongodb fixes this issue.

Essentially this needs to be done for other dockers as well, but Dockerfile requires heavy changes to download and install all ARM64 tools.