### PR TITLE
added Go_Virustotal discovery tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN wget https://github.com/Abhinandan-Khurana/go_virustotal/releases/download/v
 RUN mv go_virustotal-linux-v1.0.1 go_virustotal
 RUN mv go_virustotal /usr/bin
 
-
 # Install HTTPX
 RUN echo "Installing HTTPX"
 RUN wget https://github.com/projectdiscovery/httpx/releases/download/v1.6.8/httpx_1.6.8_linux_amd64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN unzip subfinder_2.6.6_linux_amd64.zip
 RUN mv subfinder /usr/bin
 RUN rm -rf *
 
+# Install Go_Virustotal
+RUN echo "Installing Go_Virustotal"
+RUN wget https://github.com/Abhinandan-Khurana/go_virustotal/releases/download/v1.0.1/go_virustotal-linux-v1.0.1
+RUN mv go_virustotal-linux-v1.0.1 go_virustotal
+RUN mv go_virustotal /usr/bin
+
+
 # Install HTTPX
 RUN echo "Installing HTTPX"
 RUN wget https://github.com/projectdiscovery/httpx/releases/download/v1.6.8/httpx_1.6.8_linux_amd64.zip

--- a/configs/local.yml
+++ b/configs/local.yml
@@ -14,7 +14,7 @@ workflow:
     cmd: []
     workflowConfig:
       - moduleName : discovery
-        tools: ['Subfinder']
+        tools: ['Subfinder','Go_Virustotal']
         order: 1
       - moduleName: prerecon
         tools: ['FindCDN', 'Naabu'] 

--- a/mantis/db/db_models.py
+++ b/mantis/db/db_models.py
@@ -25,7 +25,8 @@ class Assets(BaseModel):
     updated_timestamp: Optional[str] = Field(None)
     active_hosts: Optional[list] = list()
     stale: Optional[bool] = False
-    repositories: Optional[str] = Field(None) ## if 
+    repositories: Optional[str] = Field(None)
+    tools_source: Optional[str] = Field(None)
     others: Optional[dict] = dict()
 
 

--- a/mantis/modules/discovery/Go_Virustotal.py
+++ b/mantis/modules/discovery/Go_Virustotal.py
@@ -1,0 +1,75 @@
+from mantis.constants import ASSET_TYPE_SUBDOMAIN
+from mantis.utils.crud_utils import CrudUtils
+from mantis.tool_base_classes.toolScanner import ToolScanner
+from mantis.models.args_model import ArgsModel
+from mantis.utils.tool_utils import get_assets_grouped_by_type
+from mantis.constants import ASSET_TYPE_TLD
+import json
+import os
+import logging
+
+'''
+Go_Virustotal module enumerates subdomain of the TLDs which are fetched from database. 
+Output file: .json 
+------------------
+   1   │ {
+   2   │   "tool_name": "virustotal",
+   3   │   "result": [
+   4   │     {
+   5   │       "domain_name": "example.com",
+   6   │       "results": [
+   7   │         "blog.example.com",
+   8   │         "internal.example.example",
+   9   │         "dc-admin.example.com",
+  10   │         "www.example.com"
+  11   │       ]
+  12   │     }
+  13   │   ]
+  14   │ }
+------------------
+Each subdomain discovered is inserted into the database as a new asset. 
+'''
+
+class Go_Virustotal(ToolScanner):
+
+    def __init__(self) -> None:
+        super().__init__()
+        
+    async def get_commands(self, args: ArgsModel):
+        self.VT_API_KEY = None # Provide the VT_API_KEY (Virustotal API key) token here
+        if self.VT_API_KEY is None:
+            logging.warning("VT_API_KEY token not exported, Go_Virustotal will not run successfully")
+            raise Exception("VT_API_KEY token not provided!!")
+        else:
+            os.environ['VT_API_KEY'] = self.VT_API_KEY
+        self.org = args.org
+        self.base_command = 'go_virustotal -domain {input_domain} -silent -json > {output_file_path}'
+        self.outfile_extension = ".json"
+        self.assets = await get_assets_grouped_by_type(self, args, ASSET_TYPE_TLD)
+        
+        return super().base_get_commands(self.assets)
+    
+    def parse_report(self, outfile):
+        output_dict_list = []
+        
+        # Read and parse JSON file
+        with open(outfile) as f:
+            vt_output = json.load(f)
+            print("VTTTT",vt_output)
+        
+        # Process each domain result
+        for domain_obj in vt_output['result']:
+            for subdomain in domain_obj['results']:
+                domain_dict = {
+                    '_id': subdomain,
+                    'asset': subdomain,
+                    'asset_type': ASSET_TYPE_SUBDOMAIN,
+                    'org': self.org,
+                    'tool_source': 'Go_Virustotal'
+                }
+                output_dict_list.append(domain_dict)
+        print(output_dict_list)
+        return output_dict_list
+    
+    async def db_operations(self, tool_output_dict, asset=None):
+        await CrudUtils.insert_assets(tool_output_dict)

--- a/mantis/modules/discovery/Subfinder.py
+++ b/mantis/modules/discovery/Subfinder.py
@@ -32,8 +32,8 @@ class Subfinder(ToolScanner):
             domain_dict['asset'] = domain.rstrip('\n')
             domain_dict['asset_type'] = ASSET_TYPE_SUBDOMAIN
             domain_dict['org'] = self.org
+            domain_dict['tools_source'] = 'subfinder'
             output_dict_list.append(domain_dict)
-
         return output_dict_list
     
     async def db_operations(self, tool_output_dict, asset=None):


### PR DESCRIPTION
This PR adds Go_Virustotal as a new discovery tool to enhance the subdomain enumeration capabilities of Mantis.

Changes made:
- Integrated Go_Virustotal for VirusTotal-based subdomain enumeration
NOTE: Needs VT_API_KEY to be added into the code to get it working.

This addition addresses part of issue #79 to expand the discovery module's toolset. 

Go_Virustotal will complement the existing SSLMate and subfinder tools by leveraging VirusTotal's extensive database for subdomain discovery.

Please review and let me know if any changes are fine.

Closes https://github.com/PhonePe/mantis/issues/79 (partially)
