### PR TITLE
Added cross-platfrom support via tonistiigi/binfmt

### DIFF
--- a/setup/docker/docker-compose.yml
+++ b/setup/docker/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  emulator:
+    # Cross-Platform support
+    # https://github.com/tonistiigi/binfmt
+    image: tonistiigi/binfmt
+    container_name: emulator
+    privileged: true
+    command: --install amd64
+    network_mode: bridge
+    restart: "no"
   mantis:
     # When testing local changes, uncomment the following commented lines and comment out "image"
     # This will build the mantis container locally instead of pulling from GHRC
@@ -16,6 +25,8 @@ services:
       - "mantis.db:10.10.0.3"
     environment:
       - "PS1='Mantis > '"
+    depends_on:
+      - emulator
   mongodb:
     container_name: mongodb
     image: mongo:latest


### PR DESCRIPTION
**Issue:** #84 

**Description:** Adds cross-platform support by installing binfmt, a cross-platform emulator collection distributed with Docker images.

**Changes:** Added dependency for `tonistiigi/binfmt` to `setup/docker/docker-compose.yml`

**Tests:** Tested on an aarch64 Oracle compute instance.

- Host and Mantis container have different architectures:
![mantis-arch](https://github.com/user-attachments/assets/7920cfc9-8d52-45e9-9815-4844381b1049)

- Mantis and its modules running without issues:
![mantis-running](https://github.com/user-attachments/assets/b6bbbad1-30d2-40e1-a72b-e9a08abbf4ac)

Please review and let me know if changes are required.
Closes #84 